### PR TITLE
feat(experiment-id): save experiment id in a dedicated table

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -26,7 +26,6 @@ class Config:
     CHAT_BASE_MODEL_NAME = "Qwen/Qwen2.5-Coder-7B-Instruct"
     CHAT_FINETUNED_MODEL_NAME = "stacklok/Qwen2.5-Coder-7B-Instruct-codegate-chat"
 
-
     # Frontend URL
     FRONTEND_URL = os.getenv('FRONTEND_URL', 'https://acme.com')
 
@@ -43,3 +42,14 @@ class Config:
     GITHUB_CALLBACK_URL = os.getenv('GITHUB_CALLBACK_URL', f"{BACKEND_URL}/auth/callback")
 
     LOCAL_ENV = os.getenv('LOCAL_ENV', False)
+
+    EXPERIMENTS = {
+        "FIM_CODEGATE": {
+            "base": FIM_BASE_MODEL_NAME,
+            "fineTuned": FIM_FINETUNED_MODEL_NAME
+        },
+        "CHAT_CODEGATE": {
+            "base": CHAT_BASE_MODEL_NAME,
+            "fineTuned": CHAT_FINETUNED_MODEL_NAME
+        }
+    }

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,11 +1,26 @@
-from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime, Text
+from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime, Text, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, relationship
 from datetime import datetime
 from enum import Enum
 
 Base = declarative_base()
 
+# New table for experiments
+class Experiment(Base):
+    __tablename__ = 'experiments'
+
+    id = Column(Integer, primary_key=True)
+    experiment_id = Column(String, nullable=False, unique=True)  # e.g., "FIM_CODEGATE"
+    created_at = Column(DateTime, default=datetime.utcnow)
+    
+    # Relationship to comparison results
+    comparisons = relationship("ComparisonResult", back_populates="experiment")
+    
+    def __repr__(self):
+        return f"<Experiment {self.experiment_id}>"
+
+# Existing ComparisonResult table with a link to experiments
 class ComparisonResult(Base):
     __tablename__ = 'comparison_results'
 
@@ -18,6 +33,10 @@ class ComparisonResult(Base):
     base_completion = Column(Text, nullable=False)
     finetuned_completion = Column(Text, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+    
+    # Foreign key to experiments table
+    experiment_id = Column(Integer, ForeignKey('experiments.id'), nullable=True)
+    experiment = relationship("Experiment", back_populates="comparisons")
 
     @classmethod
     def get_preference_stats(cls, session):

--- a/frontend/components/ExperimentSelector.tsx
+++ b/frontend/components/ExperimentSelector.tsx
@@ -1,0 +1,54 @@
+import { FC, useEffect } from "react";
+import { useExperiments } from "../hooks/useExperiments";
+import { Select } from "./Select";
+
+interface ExperimentSelectorProps {
+  value: string | undefined;
+  onChange: (experimentId: string) => void;
+  disabled?: boolean;
+  autoSelect?: boolean;
+}
+
+export const ExperimentSelector: FC<ExperimentSelectorProps> = ({
+  value,
+  onChange,
+  disabled = false,
+  autoSelect = true,
+}) => {
+  const { options, isLoading, error } = useExperiments();
+  
+  useEffect(() => {
+    if (autoSelect && !value && options.length > 0 && !disabled) {
+      onChange(options[0].value);
+    }
+  }, [autoSelect, value, options, disabled, onChange]);
+  
+  if (error) {
+    return <div className="text-red-500 text-sm">Failed to load experiments: {error}</div>;
+  }
+  
+  return (
+    <div className="mb-4">
+      <label
+        htmlFor="experiment-select"
+        className="block text-lg font-medium text-gray-200 mb-2"
+      >
+        Choose your experiments
+      </label>
+      <Select
+        id="experiment-select"
+        className="w-[200px] bg-gray-900"
+        disabled={disabled || isLoading || options.length === 0}
+        value={value ?? ''}
+        onChange={onChange}
+        options={options}
+        placeholder={isLoading ? "Loading experiments..." : "Select an experiment"}
+      />
+      {options.length === 0 && !isLoading && (
+        <div className="text-amber-600 text-sm mt-1">
+          No experiments available
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/components/Select.tsx
+++ b/frontend/components/Select.tsx
@@ -32,7 +32,6 @@ export function Select({
   ...props
 }: SelectProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedValue, setSelectedValue] = useState(value);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -52,13 +51,12 @@ export function Select({
   }, []);
 
   function handleSelect(option: SelectOption) {
-    setSelectedValue(option.value);
     onChange?.(option.value);
     setIsOpen(false);
   }
 
   const selectedOption = options.find(
-    (option) => option.value === selectedValue
+    (option) => option.value === value
   );
 
   return (
@@ -89,7 +87,7 @@ export function Select({
               key={option.value}
               className={cn(
                 "px-4 py-2 text-sm cursor-pointer hover:bg-gray-700",
-                option.value === selectedValue &&
+                option.value === value &&
                   "bg-blue-600 hover:bg-blue-700"
               )}
               onClick={() => handleSelect(option)}

--- a/frontend/hooks/useExperiments.ts
+++ b/frontend/hooks/useExperiments.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+
+type ExperimentOption = {
+  label: string;
+  value: string;
+  mode: "fim" | "chat";
+};
+
+export const useExperiments = () => {
+  const [options, setOptions] = useState<ExperimentOption[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [defaultValue, setDefaultValue] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchExperiments = async () => {
+      setIsLoading(true);
+      setError(null);
+      
+      try {
+        const response = await fetch("/api/config/experiments", {
+          method: "GET",
+          credentials: "include",
+        });
+        
+        if (!response.ok) {
+          throw new Error(`Failed to fetch experiments: ${response.status}`);
+        }
+        
+        const data = await response.json();
+        
+        const experimentOptions = data.experiments.map((experimentId: string) => {
+          const mode = experimentId.includes("FIM") ? "fim" : "chat";
+          
+          const label = experimentId
+            .replace("_", " ")
+            .split(" ")
+            .map((word, index) => index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+            .join(" ");
+          
+          return {
+            label,
+            value: experimentId,
+            mode,
+          };
+        });
+        
+        setOptions(experimentOptions);
+        
+        if (experimentOptions.length > 0) {
+          setDefaultValue(experimentOptions[0].value);
+        }
+      } catch (err) {
+        console.error("Error fetching experiments:", err);
+        setError(err instanceof Error ? err.message : "Failed to fetch experiments");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    
+    fetchExperiments();
+  }, []);
+  
+  return {
+    options,
+    isLoading,
+    error,
+    defaultValue
+  };
+};

--- a/frontend/hooks/useModels.ts
+++ b/frontend/hooks/useModels.ts
@@ -1,0 +1,114 @@
+import { useCallback, useState } from "react";
+
+export type SubmissionState = "idle" | "submitting" | "success";
+
+export const useModels = ({
+  prompt,
+  prefix,
+  suffix,
+  preferredModel,
+  experimentId
+}: {
+  prompt: string;
+  prefix: string;
+  suffix: string;
+  preferredModel: "A" | "B" | null;
+  experimentId?: string;
+}) => {
+  const [results, setResults] = useState<{
+    baseResponse: string;
+    finetunedResponse: string;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [modelAIsBase, setModelAIsBase] = useState<boolean | null>(null);
+  const [submissionState, setSubmissionState] = useState<SubmissionState>("idle");
+
+  const generate = useCallback(async () => {
+    setIsLoading(true);
+
+    let body = prompt
+      ? `prompt=${encodeURIComponent(prompt)}&mode=chat`
+      : `prefix=${encodeURIComponent(prefix)}&suffix=${encodeURIComponent(suffix)}&mode=fim`;
+    
+    if (experimentId) {
+      body += `&experiment_id=${encodeURIComponent(experimentId)}`;
+    }
+  
+    try {
+      const response = await fetch("/api/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        credentials: "include",
+        body,
+      });
+  
+      const data = await response.json();
+      setModelAIsBase(data.modelAIsBase);
+      setResults({
+        baseResponse: data.modelAIsBase ? data.modelA : data.modelB,
+        finetunedResponse: data.modelAIsBase ? data.modelB : data.modelA,
+      });
+    } catch (error) {
+      console.error("Error:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [prompt, prefix, suffix, experimentId]);
+
+  const submitPreference = useCallback(async () => {
+    if (!results || preferredModel === null || modelAIsBase === null) {
+      console.error("Cannot submit preference: missing required data");
+      return;
+    }
+
+    setSubmissionState("submitting");
+
+    const preferredModelType =
+      (preferredModel === "A" && modelAIsBase) ||
+      (preferredModel === "B" && !modelAIsBase)
+        ? "base"
+        : "finetuned";
+
+    try {
+      await fetch("/api/submit-preference", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+          preferredModel: preferredModelType,
+          codePrefix: prefix || prompt,
+          baseCompletion: results.baseResponse,
+          finetunedCompletion: results.finetunedResponse,
+          experimentId: experimentId,
+        }),
+      });
+
+      setSubmissionState("success");
+
+      // Reset form after 2 seconds
+      setTimeout(() => {
+        setResults(null);
+        setModelAIsBase(null);
+        setSubmissionState("idle");
+      }, 2000);
+
+    } catch (error) {
+      console.error("Error submitting preference:", error);
+      setSubmissionState("idle");
+    }
+  }, [preferredModel, modelAIsBase, results, prefix, prompt, experimentId]);
+
+  return {
+    results,
+    isLoading,
+    modelAIsBase,
+    submissionState,
+    preferredModel,
+    generate,
+    submitPreference
+  };
+};


### PR DESCRIPTION
In this PR, we are adding a new endpoint to retrieve all possible experiments. Currently, we only have FIM_CODEGATE and CHAT_CODEGATE, but we plan to add multiple experiments in the future. We only need to expand the mapping as new experiments are added.

On the frontend, we are retrieving all possible experiments and displaying them in a dropdown menu. We are also saving the experiment ID and passing it to the generate and submit-preference endpoints so we can store this information in the database.

To handle the experiment ID, I've added a new table that stores this information with a relation to the comparison ID.

Experiment Breakdown in the admin panel
We've implemented a new section in the admin panel that provides a breakdown of experiments. This feature allows administrators to view and analyze the distribution and performance of different experiments, helping with data-driven decision making for future improvements.


<img width="1303" alt="Screenshot 2025-03-14 at 13 58 18" src="https://github.com/user-attachments/assets/15ed4a84-b669-4b95-94d3-e3fa4a57cd36" />
<img width="1513" alt="Screenshot 2025-03-14 at 13 59 07" src="https://github.com/user-attachments/assets/f103e813-98af-430c-831d-43dbe6b6890a" />
